### PR TITLE
Updated cqlsh command to connect to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install `Compose`, use:
 
 The `seed node` (`DC1N1`) exposes ports `9042, 9160` so you can connect from your development host using a recent download of Cassandra:
 
-    $ cqlsh localhost 9042
+    $ cqlsh 127.0.0.1 9042 --cqlversion 3.4.4
 
 both arguments **are required**.
 


### PR DESCRIPTION
Connection Error was received when
```
 $ cqlsh 127.0.0.1 9042
```
Connection error: ('Unable to connect to any servers', {'127.0.0.1':
ProtocolError("cql_version '3.3.1' is not supported by remote (w/ native protocol). Supported versions: [u'3.4.4']",)})